### PR TITLE
Fix compilation error when Flint is unused

### DIFF
--- a/include/fflow/multivariate_reconstruction.hh
+++ b/include/fflow/multivariate_reconstruction.hh
@@ -8,7 +8,6 @@
 #include <fflow/univariate_reconstruction.hh>
 #include <fflow/multivariate_reconstruction_details.hh>
 #include <fflow/function_cache.hh>
-#include <flint/flint.h>
 
 namespace fflow {
 


### PR DESCRIPTION
Hello Tiziano,

I get a compilation error when I try to build FiniteFlow with `-DFFLOW_USE_FLINT=0`. I think the reason is that `flint.h` is unconditionally included in `multivariate_reconstruction.hh`. It seems that simply removing this line fixes the issue—I checked that now the library compiles without errors (both with and without Flint installed) and C API and Mathematica tests still pass.

Best,
Pavel